### PR TITLE
Model types

### DIFF
--- a/src/erd.pest
+++ b/src/erd.pest
@@ -97,11 +97,15 @@ options = @{
 opt_name = !{
     "label"
     | "color"
-    | "size"
     | "bgcolor"
+    | "size"
     | "font"
-    | "border-color"
     | "border"
+    | "border-color"
+    | "cellspacing"
+    | "cellborder"
+    | "cellpadding"
+    | "text-alignment"
 }
 
 /// green

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #[macro_use]
 extern crate pest_derive;
 
+pub mod models;
 pub mod parser;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,73 @@
+//! These types represent a more programmer-friendly organization of the
+//! data slurped up from the parser.
+//!
+//! Where the raw data extracted from a plain-text ER file includes more
+//! information about the structure of the, document the types here are more to
+//! do with the structure of the diagram (our final output will be a dot
+//! language representation of this).
+
+use std::collections::HashMap;
+
+/// The haskell version refers to this as "global options" in the parser but
+/// also "directives."
+///
+/// Formatting options can be specified for each of these directive types, and
+/// the options set will provide a fallback for each when rendering the
+/// various object types in the graph.
+pub type GlobalOptions = HashMap<Directive, Options>;
+
+/// A collection of formatting options.
+pub type Options = HashMap<FormatOption, String>;
+
+pub struct Attribute {
+    field: String,
+    pk: bool,
+    fk: bool,
+    options: Options,
+}
+
+/// Defined at each side of a [Relation](struct.Relation.html) a cardinality
+/// describes the count constraints for each entity.
+pub enum Cardinality {
+    ZeroOne,
+    One,
+    ZeroPlus,
+    OnePlus,
+}
+
+/// Used as a key for the [GlobalOptions](type.GlobalOptions.html) type.
+pub enum Directive {
+    Title,
+    Header,
+    Entity,
+    Relationship,
+}
+
+pub struct Entity {
+    name: String,
+    attribs: Vec<Attribute>,
+    options: Options,
+}
+
+/// Used as a key in the [Options](type.Options.html) type.
+// FIXME: looks like there are several options that are valid that we haven't
+//  modeled in the grammar yet.
+//  https://github.com/BurntSushi/erd/blob/c5c6e1e7971a53c513aa27edd902cfd6492a57cf/src/Erd/ER.hs#L73-L86
+pub enum FormatOption {
+    Label,
+    Color,
+    Size,
+    BgColor,
+    Font,
+    BorderColor,
+    Border,
+    // ... more to be added
+}
+
+pub struct Relation {
+    entity1: String,
+    entity2: String,
+    card1: Cardinality,
+    card2: Cardinality,
+    options: Options,
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -50,18 +50,17 @@ pub struct Entity {
 }
 
 /// Used as a key in the [Options](type.Options.html) type.
-// FIXME: looks like there are several options that are valid that we haven't
-//  modeled in the grammar yet.
-//  https://github.com/BurntSushi/erd/blob/c5c6e1e7971a53c513aa27edd902cfd6492a57cf/src/Erd/ER.hs#L73-L86
 pub enum FormatOption {
-    Label,
-    Color,
-    Size,
     BgColor,
-    Font,
-    BorderColor,
+    Color,
+    FontFace,
+    FontSize,
     Border,
-    // ... more to be added
+    BorderColor,
+    CellSpacing,
+    CellBorder,
+    CellPadding,
+    TextAlignment,
 }
 
 pub struct Relation {


### PR DESCRIPTION
Aims to fix #4.

Adds types that will be used as a post-parse, but pre-render representation of the graph.