### PR TITLE
Adds `thiserror`, and an error enum for the lib.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 pest = "2.1.3"
 pest_derive = "2.1.0"
+thiserror = "1.0.19"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,5 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Parser(#[from] pest::error::Error<crate::parser::Rule>),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #[macro_use]
 extern crate pest_derive;
 
+mod errors;
 pub mod models;
 pub mod parser;
+
+pub use errors::Error;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use pest::{iterators::Pairs, Parser};
 
 #[derive(Parser)]
@@ -7,7 +8,7 @@ struct ErdParser;
 /// Parse an er file to get some pairs.
 // TODO: Likely this will not be something we offer in the public API, but it's
 //   useful to keep the `dump` example compiling for now.
-pub fn parse_pairs<'a>(input: &'a str) -> Result<Pairs<Rule>, Box<dyn std::error::Error>> {
+pub fn parse_pairs(input: &str) -> Result<Pairs<Rule>> {
     Ok(ErdParser::parse(Rule::document, input)?)
 }
 


### PR DESCRIPTION
Fixes #8.