### PR TITLE
Stubs

### DIFF
--- a/src/er.rs
+++ b/src/er.rs
@@ -54,13 +54,13 @@ pub struct Attribute {
 
 /// Default ordering for `Attribute` (by field name).
 impl Ord for Attribute {
-    fn cmp(&self, other: &Self) -> Ordering {
+    fn cmp(&self, _other: &Self) -> Ordering {
         unimplemented!()
     }
 }
 /// Default ordering for `Attribute` (by field name).
 impl PartialOrd for Attribute {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
         unimplemented!()
     }
 }
@@ -68,10 +68,16 @@ impl PartialOrd for Attribute {
 /// The haskell version refers to this as "global options" in the parser but
 /// also "directives."
 ///
-/// Formatting options can be specified for each of these directive types, and
-/// the options set will provide a fallback for each when rendering the
-/// various object types in the graph.
-pub type GlobalOptions = HashMap<Directive, Options>;
+/// Formatting options can be specified for each of these directive types in the
+/// header section of the er file.
+/// The options will provide a fallback for each when rendering the various
+/// object types in the graph.
+pub struct GlobalOptions {
+    title: Options,
+    header: Options,
+    entity: Options,
+    relationship: Options,
+}
 
 /// Used as a key for the [GlobalOptions](type.GlobalOptions.html) type.
 #[derive(Debug, PartialEq)]
@@ -85,15 +91,15 @@ pub enum Directive {
 /// A collection of formatting options.
 #[derive(Debug)]
 // FIXME:
-//  Seems like the `Options`/`FormatOption` type might be all wrong.
+//  Seems like the `Options`/`Opt` type might be all wrong.
 //  We need specific key names matched against specific value types.
 //  This sounds like a struct to me, but a struct would not give us the
 //  filter-ability needed to run selectors over without a common type for the
 //  values.
-//  Perhaps we need to change `FormatOptions` to carry a typed value in each
+//  Perhaps we need to change `Opt`s to carry a typed value in each
 //  variant. Each variant would correspond to a string name. The `Options` type
-//  would then become `HashMap<String, FormatOption>` (if still relevant).
-pub struct Options(HashMap<FormatOption, String>);
+//  would then become `HashMap<String, Opt>` (if still relevant).
+pub struct Options(HashMap<String, Opt>);
 
 impl Eq for Options {
     fn assert_receiver_is_total_eq(&self) {
@@ -102,26 +108,63 @@ impl Eq for Options {
 }
 
 impl PartialEq for Options {
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, _other: &Self) -> bool {
         unimplemented!()
     }
 }
 
-type OptEntry<'m> = Entry<'m, FormatOption, String>;
+type OptEntry<'m> = Entry<'m, Opt, String>;
+
+// The following type aliases are stubs matching the Haskell types (mostly).
+// In many cases, the types used to represent these formatting options are
+// selected based on the graphviz api being used, but for us we have no such
+// wrapper to align with. *Practically speaking* we could represent all these
+// values as String and just pass them straight through in our dot output.
+//
+// This may in fact be what we need to do.
+
+// Seems like this is going to be any valid hex color, or one of the named
+// colors available in html.
+// <https://graphviz.gitlab.io/_pages/doc/info/colors.html>
+type Color = String;
+type Text = String;
+type Double = f64;
+type Word8 = u8;
+// FIXME: change to an enum?
+//  Described in <https://www.graphviz.org/doc/info/shapes.html#html> as:
+//  > specifies horizontal placement. When an object is allocated more space
+//  > than required, this value determines where the extra space is placed left
+//  > and right of the object.
+//  >  - CENTER aligns the object in the center. (Default)
+//  >  - LEFT aligns the object on the left.
+//  >  - RIGHT aligns the object on the right.
+//  >  - (<TD> only) TEXT aligns lines of text using the full cell width. The
+//       alignment of a line is determined by its (possibly implicit) associated
+//       <BR> element.
+//  >
+//  > The contents of a cell are normally aligned as a block.
+//  > In particular, lines of text are first aligned as a text block based on
+//  > the width of the widest line and the corresponding <BR> elements.
+//  > Then, the entire text block is aligned within a cell. If, however, the
+//  > cell's ALIGN value is "TEXT", and the cell contains lines of text, then
+//  > the lines are justified using the entire available width of the cell. If
+//  > the cell does not contain text, then the contained image or table is
+//  > centered.
+type Align = String;
 
 /// Used as a key in the [Options](type.Options.html) type.
 #[derive(Debug, PartialEq)]
-pub enum FormatOption {
-    BgColor,
-    Color,
-    FontFace,
-    FontSize,
-    Border,
-    BorderColor,
-    CellSpacing,
-    CellBorder,
-    CellPadding,
-    TextAlignment,
+pub enum Opt {
+    BgColor(Color),
+    Color(Color),
+    FontFace(Text),
+    FontSize(Double),
+    Border(Word8),
+    BorderColor(Color),
+    CellSpacing(Word8),
+    CellBorder(Word8),
+    CellPadding(Word8),
+    TextAlignment(Align),
 }
 
 /// Given two sets of options, merge the second into first, where elements
@@ -144,9 +187,7 @@ where
 /// `option_by_name` will attempt to parse the string as a value corresponding
 /// to the option. If the option doesn't exist or there was a problem parsing
 /// the value, an error is returned.
-fn option_by_name(_name: &str, _value: &str) -> Result<()> {
-    // FIXME: need a way to unify the return type.
-    //  `FormatOption` with an inner value?
+fn option_by_name(_name: &str, _value: &str) -> Result<Opt> {
     unimplemented!()
 }
 
@@ -161,18 +202,18 @@ fn option_parse() -> Result<()> {
 }
 
 /// Selects an option if and only if it corresponds to a font attribute.
-fn opt_to_font(_opt: &FormatOption) -> Option<&FormatOption> {
+fn opt_to_font(_opt: &Opt) -> Option<&Opt> {
     unimplemented!()
 }
 
 /// Selects an option if and only if it corresponds to an HTML attribute.
 /// In particular, for tables or table cells.
-fn opt_to_html(_opt: &FormatOption) -> Option<&FormatOption> {
+fn opt_to_html(_opt: &Opt) -> Option<&Opt> {
     unimplemented!()
 }
 
 /// Selects an option if and only if it corresponds to a label.
-fn opt_to_label(_opt: &FormatOption) -> Option<&FormatOption> {
+fn opt_to_label(_opt: &Opt) -> Option<&Opt> {
     unimplemented!()
 }
 

--- a/src/er.rs
+++ b/src/er.rs
@@ -7,7 +7,63 @@
 //! language representation of this).
 
 use crate::Result;
+use std::cmp::Ordering;
 use std::collections::hash_map::{Entry, HashMap};
+use std::fmt::{Display, Formatter};
+
+/// Represents a single schema.
+#[derive(Debug, PartialEq)]
+pub struct ER {
+    entities: Vec<Entity>,
+    rels: Vec<Relation>,
+    title: Options,
+}
+
+/// Represents a single entity in a schema.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Entity {
+    name: String,
+    attribs: Vec<Attribute>,
+    /// Formatting options for the header.
+    hoptions: Options,
+    /// Formatting options for the entity "body."
+    eoptions: Options,
+}
+
+/// Default ordering for `Entity` (by name).
+impl Ord for Entity {
+    fn cmp(&self, _other: &Self) -> Ordering {
+        unimplemented!()
+    }
+}
+/// Default ordering for `Entity` (by name).
+impl PartialOrd for Entity {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        unimplemented!()
+    }
+}
+
+/// Represents an attribute on a particular entity.
+#[derive(Debug, Eq, PartialEq)]
+pub struct Attribute {
+    field: String,
+    pk: bool,
+    fk: bool,
+    options: Options,
+}
+
+/// Default ordering for `Attribute` (by field name).
+impl Ord for Attribute {
+    fn cmp(&self, other: &Self) -> Ordering {
+        unimplemented!()
+    }
+}
+/// Default ordering for `Attribute` (by field name).
+impl PartialOrd for Attribute {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        unimplemented!()
+    }
+}
 
 /// The haskell version refers to this as "global options" in the parser but
 /// also "directives."
@@ -17,19 +73,44 @@ use std::collections::hash_map::{Entry, HashMap};
 /// various object types in the graph.
 pub type GlobalOptions = HashMap<Directive, Options>;
 
+/// Used as a key for the [GlobalOptions](type.GlobalOptions.html) type.
+#[derive(Debug, PartialEq)]
+pub enum Directive {
+    Title,
+    Header,
+    Entity,
+    Relationship,
+}
+
+/// A collection of formatting options.
+#[derive(Debug)]
 // FIXME:
-//  Seems like the `Options`/`FormatOption` type might be all wrong. We need specific key
-//  names matched against specific value types. This sounds like a struct
-//  to me, but a struct would not give us the filter-ability needed to run
-//  selectors over without a common type for the values.
+//  Seems like the `Options`/`FormatOption` type might be all wrong.
+//  We need specific key names matched against specific value types.
+//  This sounds like a struct to me, but a struct would not give us the
+//  filter-ability needed to run selectors over without a common type for the
+//  values.
 //  Perhaps we need to change `FormatOptions` to carry a typed value in each
 //  variant. Each variant would correspond to a string name. The `Options` type
 //  would then become `HashMap<String, FormatOption>` (if still relevant).
-/// A collection of formatting options.
-pub type Options = HashMap<FormatOption, String>;
+pub struct Options(HashMap<FormatOption, String>);
+
+impl Eq for Options {
+    fn assert_receiver_is_total_eq(&self) {
+        unimplemented!()
+    }
+}
+
+impl PartialEq for Options {
+    fn eq(&self, other: &Self) -> bool {
+        unimplemented!()
+    }
+}
+
 type OptEntry<'m> = Entry<'m, FormatOption, String>;
 
 /// Used as a key in the [Options](type.Options.html) type.
+#[derive(Debug, PartialEq)]
 pub enum FormatOption {
     BgColor,
     Color,
@@ -43,54 +124,16 @@ pub enum FormatOption {
     TextAlignment,
 }
 
-pub struct Attribute {
-    field: String,
-    pk: bool,
-    fk: bool,
-    options: Options,
-}
-
-/// Defined at each side of a [Relation](struct.Relation.html) a cardinality
-/// describes the count constraints for each entity.
-pub enum Cardinality {
-    ZeroOne,
-    One,
-    ZeroPlus,
-    OnePlus,
-}
-
-/// Used as a key for the [GlobalOptions](type.GlobalOptions.html) type.
-pub enum Directive {
-    Title,
-    Header,
-    Entity,
-    Relationship,
-}
-
-pub struct Entity {
-    name: String,
-    attribs: Vec<Attribute>,
-    options: Options,
-}
-
-pub struct Relation {
-    entity1: String,
-    entity2: String,
-    card1: Cardinality,
-    card2: Cardinality,
-    options: Options,
-}
-
 /// Given two sets of options, merge the second into first, where elements
 /// in the first take precedence.
-fn merge_opts(_: Options, _: Options) -> Options {
+fn merge_opts(_: &Options, _: &Options) -> Options {
     unimplemented!()
 }
 
 /// Given a set of options and a selector function, return the list of
 /// only those options which matched. Examples of the selector function are
 /// `opt_to_font`, `opt_to_html` and `opt_to_label`.
-fn options_to<'a, F>(_: &'a Options, _: F) -> Options
+fn options_to<'a, F>(_selector: F, _options: &'a Options) -> Options
 where
     F: Fn(&OptEntry<'a>) -> Option<&'a OptEntry<'a>>,
 {
@@ -101,7 +144,7 @@ where
 /// `option_by_name` will attempt to parse the string as a value corresponding
 /// to the option. If the option doesn't exist or there was a problem parsing
 /// the value, an error is returned.
-fn option_by_name(_: &str, _: &str) -> Result<()> {
+fn option_by_name(_name: &str, _value: &str) -> Result<()> {
     // FIXME: need a way to unify the return type.
     //  `FormatOption` with an inner value?
     unimplemented!()
@@ -130,5 +173,59 @@ fn opt_to_html(_opt: &FormatOption) -> Option<&FormatOption> {
 
 /// Selects an option if and only if it corresponds to a label.
 fn opt_to_label(_opt: &FormatOption) -> Option<&FormatOption> {
+    unimplemented!()
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Relation {
+    entity1: String,
+    entity2: String,
+    card1: Cardinality,
+    card2: Cardinality,
+    options: Options,
+}
+
+/// Defined at each side of a [Relation](struct.Relation.html) a cardinality
+/// describes the count constraints for each entity.
+#[derive(Debug, PartialEq)]
+pub enum Cardinality {
+    ZeroOne,
+    One,
+    ZeroPlus,
+    OnePlus,
+}
+
+impl Display for Cardinality {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
+        unimplemented!()
+    }
+}
+
+fn card_by_name(_: char) -> Option<Cardinality> {
+    unimplemented!()
+}
+
+/// Hard-coded default options for all graph titles.
+fn default_title_opts() -> Options {
+    unimplemented!()
+}
+
+/// Hard-coded default options for all entity headers.
+fn default_header_opts() -> Options {
+    unimplemented!()
+}
+
+/// Hard-coded default options for all entities.
+fn default_entity_opts() -> Options {
+    unimplemented!()
+}
+
+/// Hard-coded default options for all relationships.
+fn default_rel_opts() -> Options {
+    unimplemented!()
+}
+
+/// Hard-coded default options for all attributes.
+fn default_attr_opts() -> Options {
     unimplemented!()
 }

--- a/src/er.rs
+++ b/src/er.rs
@@ -6,7 +6,8 @@
 //! do with the structure of the diagram (our final output will be a dot
 //! language representation of this).
 
-use std::collections::HashMap;
+use crate::Result;
+use std::collections::hash_map::{Entry, HashMap};
 
 /// The haskell version refers to this as "global options" in the parser but
 /// also "directives."
@@ -16,8 +17,31 @@ use std::collections::HashMap;
 /// various object types in the graph.
 pub type GlobalOptions = HashMap<Directive, Options>;
 
+// FIXME:
+//  Seems like the `Options`/`FormatOption` type might be all wrong. We need specific key
+//  names matched against specific value types. This sounds like a struct
+//  to me, but a struct would not give us the filter-ability needed to run
+//  selectors over without a common type for the values.
+//  Perhaps we need to change `FormatOptions` to carry a typed value in each
+//  variant. Each variant would correspond to a string name. The `Options` type
+//  would then become `HashMap<String, FormatOption>` (if still relevant).
 /// A collection of formatting options.
 pub type Options = HashMap<FormatOption, String>;
+type OptEntry<'m> = Entry<'m, FormatOption, String>;
+
+/// Used as a key in the [Options](type.Options.html) type.
+pub enum FormatOption {
+    BgColor,
+    Color,
+    FontFace,
+    FontSize,
+    Border,
+    BorderColor,
+    CellSpacing,
+    CellBorder,
+    CellPadding,
+    TextAlignment,
+}
 
 pub struct Attribute {
     field: String,
@@ -49,24 +73,62 @@ pub struct Entity {
     options: Options,
 }
 
-/// Used as a key in the [Options](type.Options.html) type.
-pub enum FormatOption {
-    BgColor,
-    Color,
-    FontFace,
-    FontSize,
-    Border,
-    BorderColor,
-    CellSpacing,
-    CellBorder,
-    CellPadding,
-    TextAlignment,
-}
-
 pub struct Relation {
     entity1: String,
     entity2: String,
     card1: Cardinality,
     card2: Cardinality,
     options: Options,
+}
+
+/// Given two sets of options, merge the second into first, where elements
+/// in the first take precedence.
+fn merge_opts(_: Options, _: Options) -> Options {
+    unimplemented!()
+}
+
+/// Given a set of options and a selector function, return the list of
+/// only those options which matched. Examples of the selector function are
+/// `opt_to_font`, `opt_to_html` and `opt_to_label`.
+fn options_to<'a, F>(_: &'a Options, _: F) -> Options
+where
+    F: Fn(&OptEntry<'a>) -> Option<&'a OptEntry<'a>>,
+{
+    unimplemented!()
+}
+
+/// Given an option name and a string representation of its value,
+/// `option_by_name` will attempt to parse the string as a value corresponding
+/// to the option. If the option doesn't exist or there was a problem parsing
+/// the value, an error is returned.
+fn option_by_name(_: &str, _: &str) -> Result<()> {
+    // FIXME: need a way to unify the return type.
+    //  `FormatOption` with an inner value?
+    unimplemented!()
+}
+
+/// A wrapper around the GraphViz's parser for any particular option.
+fn option_parse() -> Result<()> {
+    // FIXME: this one is probably not going to help us if we don't have a dot
+    //  parser. It also seems like our pest parser should already know how to
+    //  break up the quoted strings.
+    //  For us, we'll probably have to generate the dot blind and let the dot
+    //  cli handle this sort of validation.
+    unimplemented!()
+}
+
+/// Selects an option if and only if it corresponds to a font attribute.
+fn opt_to_font(_opt: &FormatOption) -> Option<&FormatOption> {
+    unimplemented!()
+}
+
+/// Selects an option if and only if it corresponds to an HTML attribute.
+/// In particular, for tables or table cells.
+fn opt_to_html(_opt: &FormatOption) -> Option<&FormatOption> {
+    unimplemented!()
+}
+
+/// Selects an option if and only if it corresponds to a label.
+fn opt_to_label(_opt: &FormatOption) -> Option<&FormatOption> {
+    unimplemented!()
 }


### PR DESCRIPTION
Lots and lots of empty functions. This diff targets the code in the [`ER` module](https://github.com/BurntSushi/erd/blob/c5c6e1e7971a53c513aa27edd902cfd6492a57cf/src/Erd/ER.hs) from the original haskell.

I reordered the symbols in our version to match the original, and note some functions that may not make the final cut. The haskell version produces images via graphviz directly, whereas I'm aiming to decouple that part (I want to generate dot language so I can visualize after the fact).

During this process, I noted some disparity in how I was planning to handle the formatting options and the original. I'm going to do another pass before this PR is ready.

---

Yep. A slight tweak from the very first draft on these types. The format options are going to now be stored as a `HashMap<String, Opt>` where an `Opt` is an enum with a variant for each specific option. Each variant will also carry an inner value which is *sorta* typed, but really I think we could probably start out by just using strings for all of them since we're going to be writing them back out into html strings as attributes...

I'd like to continue down a path where we attempt to convert all these option values into more strict types in this crate before we dump them back into the final output. This will require reading up more on the "html-like" label format supported by graphviz so we can validate more appropriately.

<https://www.graphviz.org/doc/info/shapes.html#html>

While this is not complete (based on the ongoing option-validation), the broad strokes are here. We have a bunch of functions that can be implemented and refactored as we go.

---
Fixes #5 (or close enough).